### PR TITLE
Switch to Pillow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,8 +102,6 @@ MANIFEST
 
 
 
-
-
 # Installer logs
 
 

--- a/build.spec
+++ b/build.spec
@@ -1,0 +1,40 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['src/main.py'],
+    pathex=['src'],
+    binaries=[],
+    datas=[
+        ('main.ui', '.'),
+        ('icons/*', 'icons'),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='drawing-app',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=True,
+    upx=True,
+    console=False,
+    onefile=True,
+)
+

--- a/main.ui
+++ b/main.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>758</width>
-    <height>618</height>
+    <width>912</width>
+    <height>572</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -5632,7 +5632,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>icons/color_select.png</normaloff>icons/color_select.png</iconset>
+              <normaloff>../../../.designer/backup/icons/color_select.png</normaloff>../../../.designer/backup/icons/color_select.png</iconset>
             </property>
            </widget>
           </item>
@@ -6136,7 +6136,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>icons/pencil.png</normaloff>icons/pencil.png</iconset>
+              <normaloff>../../../.designer/backup/icons/pencil.png</normaloff>../../../.designer/backup/icons/pencil.png</iconset>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -6159,7 +6159,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>icons/eraser.png</normaloff>icons/eraser.png</iconset>
+              <normaloff>../../../.designer/backup/icons/eraser.png</normaloff>../../../.designer/backup/icons/eraser.png</iconset>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -6179,7 +6179,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>icons/rectangle.png</normaloff>icons/rectangle.png</iconset>
+              <normaloff>../../../.designer/backup/icons/rectangle.png</normaloff>../../../.designer/backup/icons/rectangle.png</iconset>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -6199,7 +6199,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>icons/paint-bucket.png</normaloff>icons/paint-bucket.png</iconset>
+              <normaloff>../../../.designer/backup/icons/paint-bucket.png</normaloff>../../../.designer/backup/icons/paint-bucket.png</iconset>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -6219,7 +6219,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>icons/line.png</normaloff>icons/line.png</iconset>
+              <normaloff>../../../.designer/backup/icons/line.png</normaloff>../../../.designer/backup/icons/line.png</iconset>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -6239,7 +6239,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>icons/circle.png</normaloff>icons/circle.png</iconset>
+              <normaloff>../../../.designer/backup/icons/circle.png</normaloff>../../../.designer/backup/icons/circle.png</iconset>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -6336,7 +6336,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>758</width>
+     <width>912</width>
      <height>24</height>
     </rect>
    </property>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==2.2.6
-opencv-python-headless==4.12.0.88
+pillow==11.3.0
 PyQt5==5.15.11
 PyQt5-Qt5==5.15.17
 PyQt5_sip==12.17.0

--- a/src/canvas_view.py
+++ b/src/canvas_view.py
@@ -1,10 +1,12 @@
 from PyQt5.QtWidgets import QGraphicsView
-import cv2
 from settings import Tool
 import numpy as np
 from collections import deque
 
 from confirm_dialog import ConfirmDialog
+from draw.circle import draw_circle
+from draw.line import draw_line
+from draw.rect import draw_rectangle
 
 
 class CanvasView(QGraphicsView):
@@ -101,20 +103,24 @@ class CanvasView(QGraphicsView):
             self._canvas.refresh()
         return wrapper
 
+
     @preview_tool
     def line_tool(self, x, y):
-        cv2.line(self._canvas._arr_temp, self._line_start, (x, y), self._color_mgr.selected_bgra, self._thickness)
+        draw_line(self._canvas._arr_temp, self._line_start, (x, y),
+              self._color_mgr.selected_bgra, self._thickness)
 
     @preview_tool
     def rect_tool(self, x, y):
-        cv2.rectangle(self._canvas._arr_temp, self._line_start, (x, y), self._color_mgr.selected_bgra, self._thickness)
+        draw_rectangle(self._canvas._arr_temp, self._line_start, (x, y),
+                   self._color_mgr.selected_bgra, self._thickness)
 
     @preview_tool
     def circle_tool(self, x, y):
         dx = abs(x - self._line_start[0])
         dy = abs(y - self._line_start[1])
-        rad = round(np.sqrt(dx * dx + dy * dy))
-        cv2.circle(self._canvas._arr_temp, self._line_start, rad, self._color_mgr.selected_bgra, self._thickness)
+        rad = round(np.sqrt(dx*dx + dy*dy))
+        draw_circle(self._canvas._arr_temp, self._line_start, rad,
+                    self._color_mgr.selected_bgra, self._thickness)
 
     def clear_screen(self):
         if not self._canvas:
@@ -147,7 +153,6 @@ class CanvasView(QGraphicsView):
     def handle_release(self, event):
         if not self._canvas or event is None:
             return
-
         scene_pos = self.mapToScene(event.pos())
         x = int(scene_pos.x() / self._canvas._scale_factor)
         y = int(scene_pos.y() / self._canvas._scale_factor)
@@ -155,16 +160,19 @@ class CanvasView(QGraphicsView):
         if self._line_start is not None:
             match self._tools_mgr.selected:
                 case Tool.LINE.value:
-                    cv2.line(self._canvas._arr, self._line_start, (x, y), self._color_mgr.selected_bgra, self._thickness)
+                    draw_line(self._canvas._arr, self._line_start, (x, y),
+                      self._color_mgr.selected_bgra, self._thickness)
 
                 case Tool.RECT.value:
-                    cv2.rectangle(self._canvas._arr, self._line_start, (x, y), self._color_mgr.selected_bgra, self._thickness)
+                    draw_rectangle(self._canvas._arr, self._line_start, (x, y),
+                                   self._color_mgr.selected_bgra, self._thickness)
 
                 case Tool.CIRCLE.value:
                     dx = abs(x - self._line_start[0])
                     dy = abs(y - self._line_start[1])
-                    rad = round(np.sqrt(dx * dx + dy * dy))
-                    cv2.circle(self._canvas._arr, self._line_start, rad, self._color_mgr.selected_bgra, self._thickness)
+                    rad = round(np.sqrt(dx*dx + dy*dy))
+                    draw_circle(self._canvas._arr, self._line_start, rad,
+                                self._color_mgr.selected_bgra, self._thickness)
 
         self._line_start = None
         self._canvas._arr_temp = None

--- a/src/color_mgr.py
+++ b/src/color_mgr.py
@@ -11,7 +11,7 @@ class ColorManager:
         self.m_window = m_window
         self.selected: Optional[str] = None
         self.buttons = {}
-        self.selected_custom = settings.colors["customcolor"]
+        self.selected_custom = None
         self.color_settings = settings.colors
 
     @property
@@ -37,12 +37,15 @@ class ColorManager:
         return [b, g, r, 255]
 
     def custom_color_select(self):
-        color = QColorDialog.getColor(QColor(self.selected_custom), self.m_window, "Select Color")
+        color = QColorDialog.getColor(QColor(self.selected_custom or "#ffffff"), self.m_window, "Select Color")
 
         if color.isValid():
             self.m_window.btn_customcolor.setStyleSheet(f"background-color: {color.name()};")
             self.color_settings["customcolor"] = color.name()
+            self.selected_custom = color.name()
             self.on_color_select("customcolor")
+            return True
+        return False
 
     def init(self):
         self.m_window.button_other_color.clicked.connect(self.custom_color_select)
@@ -60,6 +63,10 @@ class ColorManager:
                 btn.setChecked(False)
 
     def on_color_select(self, color: str) -> None:
+        if color == "customcolor" and self.selected_custom is None:
+            if not self.custom_color_select():
+                return
+
         new = self.buttons.get(color)
         if new is None:
             return

--- a/src/draw/circle.py
+++ b/src/draw/circle.py
@@ -1,0 +1,22 @@
+def draw_circle(arr, center, radius, color, thickness=1):
+    cx, cy = center
+    x, y = radius, 0
+    err = 0
+
+    while x >= y:
+        for dx, dy in [
+            (x, y), (y, x), (-y, x), (-x, y),
+            (-x, -y), (-y, -x), (y, -x), (x, -y)
+        ]:
+            px, py = cx + dx, cy + dy
+            if 0 <= py < arr.shape[0] and 0 <= px < arr.shape[1]:
+                arr[max(0, py-thickness//2):py+thickness//2+1,
+                    max(0, px-thickness//2):px+thickness//2+1] = color
+
+        y += 1
+        if err <= 0:
+            err += 2*y + 1
+        if err > 0:
+            x -= 1
+            err -= 2*x + 1
+

--- a/src/draw/line.py
+++ b/src/draw/line.py
@@ -1,0 +1,26 @@
+def draw_line(arr, p1, p2, color, thickness=1):
+    x0, y0 = p1
+    x1, y1 = p2
+
+    dx = abs(x1 - x0)
+    dy = -abs(y1 - y0)
+    sx = 1 if x0 < x1 else -1
+    sy = 1 if y0 < y1 else -1
+    err = dx + dy
+
+    while True:
+        if 0 <= y0 < arr.shape[0] and 0 <= x0 < arr.shape[1]:
+            arr[max(0, y0-thickness//2):y0+thickness//2+1,
+                max(0, x0-thickness//2):x0+thickness//2+1] = color
+
+        if x0 == x1 and y0 == y1:
+            break
+
+        e2 = 2 * err
+        if e2 >= dy:
+            err += dy
+            x0 += sx
+        if e2 <= dx:
+            err += dx
+            y0 += sy
+

--- a/src/draw/rect.py
+++ b/src/draw/rect.py
@@ -1,0 +1,11 @@
+from draw.line import draw_line
+
+
+def draw_rectangle(arr, p1, p2, color, thickness=1):
+    x0, y0 = p1
+    x1, y1 = p2
+    draw_line(arr, (x0, y0), (x1, y0), color, thickness)
+    draw_line(arr, (x0, y1), (x1, y1), color, thickness)
+    draw_line(arr, (x0, y0), (x0, y1), color, thickness)
+    draw_line(arr, (x1, y0), (x1, y1), color, thickness)
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,8 @@
 import sys, os
 
+from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication, QMainWindow
 from PyQt5 import uic
-
 from color_mgr import ColorManager
 from canvas import Canvas
 from tools_mgr import ToolsManager
@@ -17,7 +17,6 @@ class PaintWindow(QMainWindow):
             base_path = sys._MEIPASS
         else:
             base_path = os.path.dirname(os.path.abspath(__file__)).rstrip('src/')
-
 
         ui_path = os.path.join(base_path, "main.ui")
         uic.loadUi(ui_path, self)


### PR DESCRIPTION
In order to cut down on import sizes and pyinstaller's built binaries, the project now uses Pillow and self-made functions instead of opencv.